### PR TITLE
feat: add placeholder replacement support for Key provisioning

### DIFF
--- a/cookiecrypt.go
+++ b/cookiecrypt.go
@@ -39,10 +39,14 @@ func (CookieCrypt) CaddyModule() caddy.ModuleInfo {
 
 func (cc *CookieCrypt) Provision(ctx caddy.Context) error {
 	cc.logger = ctx.Logger()
+	repl := caddy.NewReplacer()
 
 	if cc.Prefix == "" {
 		cc.Prefix = "cc_"
 	}
+
+	// Replace placeholders in the Key such as {file./path/to/secret-key.txt}
+	cc.Key = repl.ReplaceAll(cc.Key, "")
 
 	return nil
 }


### PR DESCRIPTION
### Summary

Add placeholder replacement support for the `key` field during provisioning so Caddy placeholder providers like `{file./path/to/secret}` can be used instead of relying solely on Caddyfile environment substitution such as `{$KEY}`.

### What changed

- Added a `caddy.Replacer` during `Provision()`.
- Applied placeholder replacement to `cc.Key`.

Example:

```caddyfile
{
	order cookiecrypt before reverse_proxy
}

example.com {
	cookiecrypt {
		key {file./run/secrets/cookiecrypt.key}
		prefix "cookiecrypt_"
		allowlist "Cookie1" "Cookie2"
		denylist "Cookie3" "Cookie3"
	}
	reverse_proxy http://127.0.0.1:5173
}
```

### Result

- Allows using placeholders like `{file./path/to/key}` for the encryption key.
- Avoids exposing secrets through environment variables and commands like `caddy environ`.
- Keeps existing static key behaviour unchanged.

### Notes

Placeholder expansion is performed once during module provisioning when the configuration is loaded.