### PR TITLE
docs: note secure/httponly defaults and the replay rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,14 @@ cookiecrypt {
 	allow_inbound <patterns...>  # exceptions to block_unencrypted
 	allow_outbound <patterns...> # never encrypt these on responses
 	max_cookie_size 4096         # split threshold per Set-Cookie line (min 512)
-	secure                       # append Secure to encrypted Set-Cookies
-	httponly                     # append HttpOnly to encrypted Set-Cookies
+	secure                       # append Secure to encrypted Set-Cookies (default: off)
+	httponly                     # append HttpOnly to encrypted Set-Cookies (default: off)
 }
 ```
 
 JSON config uses the same names: `keys` (array), `cipher`, `prefix`, `block_unencrypted`, `allow_inbound`, `allow_outbound`, `max_cookie_size`, `secure`, `httponly`.
+
+Enable `secure` whenever you serve over HTTPS: encryption stops a stolen cookie being *read*, but not *replayed*, so keeping cookies off plain HTTP still matters.
 
 ### Directional model
 


### PR DESCRIPTION
Marks `secure` and `httponly` as "(default: off)" in the configuration block, matching the existing annotation on `block_unencrypted`, and adds a one-line recommendation below it:

> Enable `secure` whenever you serve over HTTPS: encryption stops a stolen cookie being *read*, but not *replayed*, so keeping cookies off plain HTTP still matters.

Both flags genuinely default to off (plain Go bools, no provisioning default) - this just makes the docs say so and explains why turning `secure` on is worthwhile even though values are encrypted.